### PR TITLE
feat(cli): add --ml-utility and --ml-target flags to sfdao run command

### DIFF
--- a/sfdao/cli/main.py
+++ b/sfdao/cli/main.py
@@ -401,11 +401,11 @@ def run(
     """
     phase2_config = _load_phase2_config_from_option(config)
 
-    if _return_if_validate_only(validate_only):
-        return
-
     if ml_utility and not ml_target:
         raise typer.BadParameter("--ml-target is required when --ml-utility is enabled.")
+
+    if _return_if_validate_only(validate_only):
+        return
 
     real_path = validate_file_exists(real, "real")
     out_dir = _resolve_out_dir(out_dir)

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -251,6 +251,29 @@ class TestRunCommand:
         assert result.exit_code != 0
         assert "ml-target" in result.output.lower() or "required" in result.output.lower()
 
+    def test_run_validate_only_still_requires_ml_target(self, tmp_path: Path) -> None:
+        """Test that validate-only mode still validates ML utility flag combinations."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "generator:\n  type: gaussian\n  n_samples: 5\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "run",
+                "--config",
+                str(config_file),
+                "--validate-only",
+                "--ml-utility",
+                "--quiet",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "ml-target" in result.output.lower() or "required" in result.output.lower()
+
     def test_run_without_ml_utility_passes_false(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

- Add `--ml-utility` flag to `sfdao run` command (matching parity with `audit`)
- Add `--ml-target` flag to `sfdao run` command for specifying the classification target column
- Validate that `--ml-target` is required when `--ml-utility` is enabled
- Pass `ml_utility` and `ml_target` through to `run_audit()` call

Closes #36

## Changes

- `sfdao/cli/main.py`: Added `--ml-utility` and `--ml-target` options to the `run` command, validation logic, and forwarding to `run_audit()`
- `tests/unit/cli/test_main.py`: Added `TestRunCommand` class with 3 TDD tests covering the new flags

## Test plan

- [x] `test_run_accepts_ml_utility_flag` — verifies flags are accepted and forwarded to `run_audit`
- [x] `test_run_ml_utility_requires_ml_target` — verifies error when `--ml-utility` is set without `--ml-target`
- [x] `test_run_without_ml_utility_passes_false` — verifies default behavior (ml_utility=False, ml_target=None)
- [x] All 130 existing tests continue to pass
- [x] `black --check .`, `flake8 sfdao tests`, `mypy sfdao` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
