### PR TITLE
test(integration): verify generator.params passthrough from YAML config (Issue #37)

### DIFF
--- a/tests/integration/test_generator_params_from_config.py
+++ b/tests/integration/test_generator_params_from_config.py
@@ -36,7 +36,9 @@ class TestGeneratorParamsFromConfig:
     """Verify that generator.params defined in config reach the generator."""
 
     def test_baseline_params_stored_from_config(self):
-        cfg = _load_phase2_config(dedent("""\
+        cfg = _load_phase2_config(
+            dedent(
+                """\
             version: 2
             seed: 1
             generator:
@@ -45,14 +47,18 @@ class TestGeneratorParamsFromConfig:
               params:
                 custom_key: hello
                 numeric_param: 99
-            """))
+            """
+            )
+        )
         gen = build_generator(cfg.generator, seed=cfg.seed)
         assert isinstance(gen, BaselineGenerator)
         assert gen.params == {"custom_key": "hello", "numeric_param": 99}
 
     def test_ctgan_params_stored_from_config(self):
         with patch("sfdao.generator.ctgan.CTGANSynthesizer"):
-            cfg = _load_phase2_config(dedent("""\
+            cfg = _load_phase2_config(
+                dedent(
+                    """\
                 version: 2
                 seed: 7
                 generator:
@@ -61,7 +67,9 @@ class TestGeneratorParamsFromConfig:
                   params:
                     epochs: 100
                     batch_size: 256
-                """))
+                """
+                )
+            )
             gen = build_generator(cfg.generator, seed=cfg.seed)
             assert isinstance(gen, CTGANGenerator)
             assert gen.params == {"epochs": 100, "batch_size": 256}
@@ -73,7 +81,9 @@ class TestGeneratorParamsFromConfig:
             patch("sfdao.generator.ctgan.CTGANSynthesizer") as mock_synth,
             patch("sfdao.generator.ctgan.SingleTableMetadata"),
         ):
-            cfg = _load_phase2_config(dedent("""\
+            cfg = _load_phase2_config(
+                dedent(
+                    """\
                 version: 2
                 generator:
                   type: ctgan
@@ -81,7 +91,9 @@ class TestGeneratorParamsFromConfig:
                   params:
                     epochs: 30
                     batch_size: 64
-                """))
+                """
+                )
+            )
             gen = build_generator(cfg.generator, seed=None)
             real_df = pd.DataFrame({"x": [1, 2, 3]})
             gen.fit(real_df)
@@ -91,18 +103,24 @@ class TestGeneratorParamsFromConfig:
             assert call_kwargs.get("batch_size") == 64
 
     def test_empty_params_is_ok(self):
-        cfg = _load_phase2_config(dedent("""\
+        cfg = _load_phase2_config(
+            dedent(
+                """\
             version: 2
             generator:
               type: baseline
               n_samples: 5
-            """))
+            """
+            )
+        )
         gen = build_generator(cfg.generator, seed=None)
         assert gen.params == {}
 
     def test_baseline_generates_samples_with_params_present(self):
         """Smoke test: BaselineGenerator still produces correct output when params set."""
-        cfg = _load_phase2_config(dedent("""\
+        cfg = _load_phase2_config(
+            dedent(
+                """\
             version: 2
             seed: 42
             generator:
@@ -110,7 +128,9 @@ class TestGeneratorParamsFromConfig:
               n_samples: 20
               params:
                 ignored_by_baseline: true
-            """))
+            """
+            )
+        )
         gen = build_generator(cfg.generator, seed=cfg.seed)
         real_df = pd.DataFrame({"amount": [10.0, 20.0, 30.0]})
         gen.fit(real_df)

--- a/tests/integration/test_generator_params_from_config.py
+++ b/tests/integration/test_generator_params_from_config.py
@@ -6,12 +6,13 @@ ignored when build_generator instantiated BaselineGenerator or CTGANGenerator.
 
 from __future__ import annotations
 
+from pathlib import Path
 from textwrap import dedent
 from unittest.mock import patch
 
 import pandas as pd
-import yaml
 
+from sfdao.config.loader import load_phase2_config
 from sfdao.config.models import Phase2Config
 from sfdao.generator.baseline import BaselineGenerator
 from sfdao.generator.ctgan import CTGANGenerator
@@ -22,9 +23,10 @@ from sfdao.generator.factory import build_generator
 # ---------------------------------------------------------------------------
 
 
-def _load_phase2_config(yaml_text: str) -> Phase2Config:
-    data = yaml.safe_load(yaml_text)
-    return Phase2Config.model_validate(data)
+def _load_phase2_config(tmp_path: Path, yaml_text: str) -> Phase2Config:
+    config_path = tmp_path / "phase2.yaml"
+    config_path.write_text(yaml_text, encoding="utf-8")
+    return load_phase2_config(config_path)
 
 
 # ---------------------------------------------------------------------------
@@ -35,8 +37,9 @@ def _load_phase2_config(yaml_text: str) -> Phase2Config:
 class TestGeneratorParamsFromConfig:
     """Verify that generator.params defined in config reach the generator."""
 
-    def test_baseline_params_stored_from_config(self):
+    def test_baseline_params_stored_from_config(self, tmp_path: Path):
         cfg = _load_phase2_config(
+            tmp_path,
             dedent(
                 """\
             version: 2
@@ -48,15 +51,16 @@ class TestGeneratorParamsFromConfig:
                 custom_key: hello
                 numeric_param: 99
             """
-            )
+            ),
         )
         gen = build_generator(cfg.generator, seed=cfg.seed)
         assert isinstance(gen, BaselineGenerator)
         assert gen.params == {"custom_key": "hello", "numeric_param": 99}
 
-    def test_ctgan_params_stored_from_config(self):
+    def test_ctgan_params_stored_from_config(self, tmp_path: Path):
         with patch("sfdao.generator.ctgan.CTGANSynthesizer"):
             cfg = _load_phase2_config(
+                tmp_path,
                 dedent(
                     """\
                 version: 2
@@ -68,20 +72,21 @@ class TestGeneratorParamsFromConfig:
                     epochs: 100
                     batch_size: 256
                 """
-                )
+                ),
             )
             gen = build_generator(cfg.generator, seed=cfg.seed)
             assert isinstance(gen, CTGANGenerator)
             assert gen.params == {"epochs": 100, "batch_size": 256}
             assert gen.seed == 7
 
-    def test_ctgan_params_passed_to_synthesizer_on_fit(self):
+    def test_ctgan_params_passed_to_synthesizer_on_fit(self, tmp_path: Path):
         """Params from config must reach CTGANSynthesizer.__init__ at fit time."""
         with (
             patch("sfdao.generator.ctgan.CTGANSynthesizer") as mock_synth,
             patch("sfdao.generator.ctgan.SingleTableMetadata"),
         ):
             cfg = _load_phase2_config(
+                tmp_path,
                 dedent(
                     """\
                 version: 2
@@ -92,7 +97,7 @@ class TestGeneratorParamsFromConfig:
                     epochs: 30
                     batch_size: 64
                 """
-                )
+                ),
             )
             gen = build_generator(cfg.generator, seed=None)
             real_df = pd.DataFrame({"x": [1, 2, 3]})
@@ -102,8 +107,9 @@ class TestGeneratorParamsFromConfig:
             assert call_kwargs.get("epochs") == 30
             assert call_kwargs.get("batch_size") == 64
 
-    def test_empty_params_is_ok(self):
+    def test_empty_params_is_ok(self, tmp_path: Path):
         cfg = _load_phase2_config(
+            tmp_path,
             dedent(
                 """\
             version: 2
@@ -111,14 +117,15 @@ class TestGeneratorParamsFromConfig:
               type: baseline
               n_samples: 5
             """
-            )
+            ),
         )
         gen = build_generator(cfg.generator, seed=None)
         assert gen.params == {}
 
-    def test_baseline_generates_samples_with_params_present(self):
+    def test_baseline_generates_samples_with_params_present(self, tmp_path: Path):
         """Smoke test: BaselineGenerator still produces correct output when params set."""
         cfg = _load_phase2_config(
+            tmp_path,
             dedent(
                 """\
             version: 2
@@ -129,7 +136,7 @@ class TestGeneratorParamsFromConfig:
               params:
                 ignored_by_baseline: true
             """
-            )
+            ),
         )
         gen = build_generator(cfg.generator, seed=cfg.seed)
         real_df = pd.DataFrame({"amount": [10.0, 20.0, 30.0]})

--- a/tests/integration/test_generator_params_from_config.py
+++ b/tests/integration/test_generator_params_from_config.py
@@ -1,0 +1,119 @@
+"""Integration tests: GeneratorSettings.params flows through to generator instances.
+
+Covers the fix for Issue #37 where params specified in YAML/config were silently
+ignored when build_generator instantiated BaselineGenerator or CTGANGenerator.
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+from unittest.mock import patch
+
+import pandas as pd
+import yaml
+
+from sfdao.config.models import Phase2Config
+from sfdao.generator.baseline import BaselineGenerator
+from sfdao.generator.ctgan import CTGANGenerator
+from sfdao.generator.factory import build_generator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_phase2_config(yaml_text: str) -> Phase2Config:
+    data = yaml.safe_load(yaml_text)
+    return Phase2Config.model_validate(data)
+
+
+# ---------------------------------------------------------------------------
+# Tests: params reach generator via build_generator
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratorParamsFromConfig:
+    """Verify that generator.params defined in config reach the generator."""
+
+    def test_baseline_params_stored_from_config(self):
+        cfg = _load_phase2_config(dedent("""\
+            version: 2
+            seed: 1
+            generator:
+              type: baseline
+              n_samples: 10
+              params:
+                custom_key: hello
+                numeric_param: 99
+            """))
+        gen = build_generator(cfg.generator, seed=cfg.seed)
+        assert isinstance(gen, BaselineGenerator)
+        assert gen.params == {"custom_key": "hello", "numeric_param": 99}
+
+    def test_ctgan_params_stored_from_config(self):
+        with patch("sfdao.generator.ctgan.CTGANSynthesizer"):
+            cfg = _load_phase2_config(dedent("""\
+                version: 2
+                seed: 7
+                generator:
+                  type: ctgan
+                  n_samples: 50
+                  params:
+                    epochs: 100
+                    batch_size: 256
+                """))
+            gen = build_generator(cfg.generator, seed=cfg.seed)
+            assert isinstance(gen, CTGANGenerator)
+            assert gen.params == {"epochs": 100, "batch_size": 256}
+            assert gen.seed == 7
+
+    def test_ctgan_params_passed_to_synthesizer_on_fit(self):
+        """Params from config must reach CTGANSynthesizer.__init__ at fit time."""
+        with (
+            patch("sfdao.generator.ctgan.CTGANSynthesizer") as mock_synth,
+            patch("sfdao.generator.ctgan.SingleTableMetadata"),
+        ):
+            cfg = _load_phase2_config(dedent("""\
+                version: 2
+                generator:
+                  type: ctgan
+                  n_samples: 5
+                  params:
+                    epochs: 30
+                    batch_size: 64
+                """))
+            gen = build_generator(cfg.generator, seed=None)
+            real_df = pd.DataFrame({"x": [1, 2, 3]})
+            gen.fit(real_df)
+
+            call_kwargs = mock_synth.call_args.kwargs
+            assert call_kwargs.get("epochs") == 30
+            assert call_kwargs.get("batch_size") == 64
+
+    def test_empty_params_is_ok(self):
+        cfg = _load_phase2_config(dedent("""\
+            version: 2
+            generator:
+              type: baseline
+              n_samples: 5
+            """))
+        gen = build_generator(cfg.generator, seed=None)
+        assert gen.params == {}
+
+    def test_baseline_generates_samples_with_params_present(self):
+        """Smoke test: BaselineGenerator still produces correct output when params set."""
+        cfg = _load_phase2_config(dedent("""\
+            version: 2
+            seed: 42
+            generator:
+              type: baseline
+              n_samples: 20
+              params:
+                ignored_by_baseline: true
+            """))
+        gen = build_generator(cfg.generator, seed=cfg.seed)
+        real_df = pd.DataFrame({"amount": [10.0, 20.0, 30.0]})
+        gen.fit(real_df)
+        synth = gen.sample(cfg.generator.n_samples)
+        assert len(synth) == 20
+        assert list(synth.columns) == ["amount"]


### PR DESCRIPTION
## Summary

- Add integration tests confirming the fix for Issue #37 where `GeneratorSettings.params` was silently ignored in `build_generator`
- Tests cover the full flow: YAML config → `Phase2Config` → `build_generator` → generator instance

## What was fixed (already in main via PR #40)

`sfdao/generator/factory.py` now unpacks `settings.params` as `**kwargs` when instantiating `BaselineGenerator` and `CTGANGenerator`. The generators pass these kwargs to `BaseGenerator.__init__` which stores them as `self.params`. `CTGANGenerator.fit` then passes `**self.params` to `CTGANSynthesizer`.

## New tests (`tests/integration/test_generator_params_from_config.py`)

- `test_baseline_params_stored_from_config` — params in YAML reach `BaselineGenerator.params`
- `test_ctgan_params_stored_from_config` — params in YAML reach `CTGANGenerator.params`
- `test_ctgan_params_passed_to_synthesizer_on_fit` — params reach `CTGANSynthesizer.__init__` at fit time
- `test_empty_params_is_ok` — no `params` key in YAML defaults to `{}`
- `test_baseline_generates_samples_with_params_present` — smoke test: generator still produces correct output

## Test plan

- [x] `pytest tests/integration/test_generator_params_from_config.py -v` — 5/5 pass
- [x] `pytest` — 136 passed, 2 skipped (all pre-existing)
- [x] `black --check .` — clean
- [x] `flake8 sfdao tests` — clean
- [x] `bandit -r sfdao` — no issues

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
