### PR TITLE
chore(release): prepare for v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-03-19
+
+### Added
+- **Guard**: `fill_to_target` option for `exclude` mode — resamples until `n_samples` rows satisfy guard constraints, ensuring consistent output size (#38).
+- **CLI**: `--ml-utility` and `--ml-target` flags added to `sfdao run` command for combined generate→guard→audit workflows (#36).
+- **Generator**: `params` from `GeneratorSettings` are now passed through to generator constructors, enabling full configuration via YAML (#37).
+
+### Changed
+- **Config**: `ScenarioSettings` simplified — `name` and `transformations` are now direct fields instead of being nested under `params`, reducing config hierarchy depth (#39).
+
 ## [0.1.0] - 2025-12-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sfdao"
-version = "0.1.0"
+version = "0.1.1"
 description = "Synthetic Finance Data Auditor & Optimizer"
 authors = ["takurot <takuro.tsujikawa@gmail.com>"]
 license = "MIT"

--- a/sfdao/__init__.py
+++ b/sfdao/__init__.py
@@ -4,4 +4,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/sfdao/cli/main.py
+++ b/sfdao/cli/main.py
@@ -40,7 +40,7 @@ console = Console()
 def version_callback(value: bool) -> None:
     """Display version and exit."""
     if value:
-        console.print("sfdao version 0.1.0")
+        console.print("sfdao version 0.1.1")
         raise typer.Exit()
 
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -30,7 +30,7 @@ class TestCliBasic:
         """Test that CLI has version option."""
         result = runner.invoke(app, ["--version"])
         assert result.exit_code == 0
-        assert "0.1.0" in result.output
+        assert "0.1.1" in result.output
 
 
 class TestAuditCommand:


### PR DESCRIPTION
## Summary

- Bump version `0.1.0` → `0.1.1` in `pyproject.toml`, `sfdao/__init__.py`, and `sfdao/cli/main.py`
- Update `CHANGELOG.md` with all changes since v0.1.0
- Update version assertion in `tests/unit/cli/test_main.py`

## Changes since v0.1.0

| PR | 内容 |
|----|------|
| #36 | CLI `sfdao run` に `--ml-utility` / `--ml-target` フラグ追加 |
| #37 | `GeneratorSettings.params` がジェネレータに渡るよう修正 |
| #38 | Guard `exclude` モードに `fill_to_target` オプション追加 |
| #39 | `ScenarioSettings` の YAML 設定構造を簡素化 |

## Test plan

- [ ] `pytest` — 156 passed, 2 skipped
- [ ] `black --check .` / `flake8 .` / `mypy sfdao` / `bandit -r sfdao` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
